### PR TITLE
Added UDPv6 transport

### DIFF
--- a/src/nserver/server.py
+++ b/src/nserver/server.py
@@ -11,7 +11,7 @@ import dnslib
 ## Application
 from .rules import RuleBase, WildcardStringRule, RegexRule
 from .models import Query, Response
-from .transport import UDPv4Transport, TCPv4Transport, TransportBase, InvalidMessageError
+from .transport import UDPv4Transport, UDPv6Transport, TCPv4Transport, TransportBase, InvalidMessageError
 from .records import RecordBase
 
 
@@ -121,6 +121,8 @@ class NameServer:
             server = TCPv4Transport(self.settings.SERVER_ADDRESS, self.settings.SERVER_PORT)
         elif server_type == "UDPv4":
             server = UDPv4Transport(self.settings.SERVER_ADDRESS, self.settings.SERVER_PORT)
+        elif server_type == "UDPv6":
+            server = UDPv6Transport(self.settings.SERVER_ADDRESS, self.settings.SERVER_PORT)
         else:
             raise ValueError(f"Unknown SERVER_TYPE: {server_type}")
 

--- a/src/nserver/transport.py
+++ b/src/nserver/transport.py
@@ -85,7 +85,7 @@ class MessageContainer:  # pylint: disable=too-few-public-methods
     Used to simplify the interface (and allow for threading etc later).
     """
 
-    SOCKET_TYPES = {"UDPv4", "TCPv4"}
+    SOCKET_TYPES = {"UDPv4", "TCPv4", "UDPv6"}
 
     def __init__(
         self,
@@ -150,11 +150,12 @@ class UDPv4Transport(TransportBase):
     """Transport class for IPv4 UDP."""
 
     SOCKET_TYPE = "UDPv4"
+    SOCKET_AF = socket.AF_INET
 
     def __init__(self, address: str, port: int):
         self.address = address
         self.port = port
-        self.socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        self.socket = socket.socket(self.SOCKET_AF, socket.SOCK_DGRAM)
         return
 
     def start_server(self, timeout=60) -> None:
@@ -191,6 +192,11 @@ class UDPv4Transport(TransportBase):
 
     def __repr__(self):
         return f"{self.__class__.__name__}(address={self.address!r}, port={self.port!r})"
+
+
+class UDPv6Transport(UDPv4Transport):
+    SOCKET_TYPE = "UDPv6"
+    SOCKET_AF = socket.AF_INET6
 
 
 # TCPv4 Server


### PR DESCRIPTION
Found this library, and have a use case for it in a IPv6 only network.
I added UDPv6 transport, to make it usable for me.
I can also add TCPv6 support if wanted, but I did not  test it yet.