### PR TITLE
[version] Fix missing import

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.1](https://github.com/nhairs/nserver/compare/v3.0.0...v3.0.1) - 2025-08-15
+
+### Fixed
+- Missing `datetime` import in `_version` affecting the CLI [#9](https://github.com/nhairs/nserver/issues/9)
 
 ## [3.0.0](https://github.com/nhairs/nserver/compare/v2.0.0...v3.0.0) - 2025-07-11
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nserver"
-version = "3.0.0"
+version = "3.0.1"
 description = "DNS Name Server Framework"
 authors  = [
     {name = "Nicholas Hairs", email = "info+nserver@nicholashairs.com"},

--- a/src/nserver/_version.py
+++ b/src/nserver/_version.py
@@ -3,6 +3,7 @@
 ### IMPORTS
 ### ============================================================================
 ## Standard Library
+import datetime  # pylint: disable=unused-import
 
 ## Installed
 


### PR DESCRIPTION
Fixes #9 

## Test Plan
- Build project: `./dev.sh build`
- Create new virtual environment `virtualenv -p python3 test_env`
- Activate and install built packaged `source test_env/bin/activate && pip install 'dist/nserver-3.0.1-py3-none-any.whl[dev]'`
- Test CLI works:
  - `nserver --help`
  - `nserver --version`
  - `nserver --server nserver/tests/test_server.py`