### PR TITLE
Drop support for Python 3.8-3.9, upgrade syntax for 3.10

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.2.0](https://github.com/nhairs/nserver/compare/v3.1.0...v3.2.0) - UNRELEASED
+
+### Removed
+- Support for Python 3.8 and 3.9
+
 ## [3.1.0](https://github.com/nhairs/nserver/compare/v3.0.2...v3.1.0) - 2026-03-01
 
 ### Added

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -92,6 +92,8 @@ In general backwards compatability is always preferred.
 
 Feature changes MUST be compatible with all [security supported versions of Python](https://endoflife.date/python) and SHOULD be compatible with all unsupported versions of Python where [recent downloads over the last 90 days exceeds 10% of all downloads](https://pypistats.org/packages/nserver).
 
+As of 2026-03-11 feature support is provided for Python `3.10+`.
+
 In general, only the latest `major.minor` version of NServer is supported. Bug fixes and feature backports requiring a version branch may be considered but must be discussed with the maintainers first.
 
 See also [Security Policy](security.md).

--- a/docs/security.md
+++ b/docs/security.md
@@ -5,7 +5,7 @@
 Security support for Python JSON Logger is provided for all [security supported versions of Python](https://endoflife.date/python) and for unsupported versions of Python where [recent downloads over the last 90 days exceeds 10% of all downloads](https://pypistats.org/packages/nserver).
 
 
-As of 2024-11-22 security support is provided for Python versions `3.8+`.
+As of 2026-03-11 security support is provided for Python versions `3.10+`.
 
 
 ## Reporting a Vulnerability

--- a/pylintrc
+++ b/pylintrc
@@ -36,10 +36,6 @@ persistent=yes
 # Specify a configuration file.
 #rcfile=
 
-# When enabled, pylint would attempt to guess common misconfiguration and emit
-# user-friendly hints instead of false-positive error messages.
-suggestion-mode=yes
-
 # Allow loading of arbitrary C extensions. Extensions are imported into the
 # active Python interpreter and may run arbitrary code.
 unsafe-load-any-extension=no

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,14 +4,14 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nserver"
-version = "3.1.0"
+version = "3.2.0.dev1"
 description = "DNS Name Server Framework"
 authors  = [
     {name = "Nicholas Hairs", email = "info+nserver@nicholashairs.com"},
 ]
 
 # Dependency Information
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 dependencies = [
     "dnslib",
     "pillar~=0.5",
@@ -25,8 +25,6 @@ license = {text = "MIT"}
 classifiers = [
     "Development Status :: 4 - Beta",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",

--- a/src/nserver/middleware.py
+++ b/src/nserver/middleware.py
@@ -6,8 +6,8 @@ from __future__ import annotations
 ## Standard Library
 import inspect
 import threading
-from typing import TYPE_CHECKING, Callable, Generic, TypeVar
-import sys
+from typing import TYPE_CHECKING, Generic, TypeVar, TypeAlias
+from collections.abc import Callable
 
 ## Installed
 import dnslib
@@ -16,13 +16,6 @@ from pillar.logging import LoggingMixin
 ## Application
 from .models import Query, Response
 from .rules import coerce_to_response, RuleResult
-
-## Special
-if sys.version_info < (3, 10):
-    from typing_extensions import TypeAlias
-else:
-    from typing import TypeAlias
-
 
 ### CONSTANTS
 ### ============================================================================

--- a/src/nserver/models.py
+++ b/src/nserver/models.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 ## Standard Library
-from typing import Optional, Union, List
 
 ## Installed
 import dnslib
@@ -57,7 +56,7 @@ class Query:  # pylint: disable=too-few-public-methods
 
 ## Response Classes
 ## -----------------------------------------------------------------------------
-OptionalRecordList = Optional[Union[RecordBase, List[RecordBase]]]
+OptionalRecordList = RecordBase | list[RecordBase] | None
 
 
 class Response:

--- a/src/nserver/rules.py
+++ b/src/nserver/rules.py
@@ -7,7 +7,9 @@ from __future__ import annotations
 
 ## Standard Library
 import re
-from typing import Callable, Pattern, Union, Type, List
+from typing import TypeAlias
+from collections.abc import Callable
+from re import Pattern
 
 ## Installed
 import dnslib
@@ -56,7 +58,7 @@ def coerce_to_response(result: RuleResult) -> Response:
     raise TypeError(f"Cannot process result: {result!r}")
 
 
-def smart_make_rule(rule: Union[Type[RuleBase], str, Pattern], *args, **kwargs) -> RuleBase:
+def smart_make_rule(rule: type[RuleBase] | str | Pattern, *args, **kwargs) -> RuleBase:
     """Create a rule using shorthand notation.
 
     The exact type of rule returned depends on what is povided by `rule`.
@@ -91,12 +93,12 @@ def smart_make_rule(rule: Union[Type[RuleBase], str, Pattern], *args, **kwargs) 
 
 ### CLASSES
 ### ============================================================================
-RuleResult = Union[Response, RecordBase, List[RecordBase], None]
+RuleResult: TypeAlias = Response | RecordBase | list[RecordBase] | None
 """
 Type Alias for the result of a rule response function
 """
 
-ResponseFunction = Callable[[Query], RuleResult]
+ResponseFunction: TypeAlias = Callable[[Query], RuleResult]
 """
 Type Alias for functions that will be called when a rule is matched
 """

--- a/src/nserver/server.py
+++ b/src/nserver/server.py
@@ -4,7 +4,8 @@
 from __future__ import annotations
 
 ## Standard Library
-from typing import TypeVar, Generic, Pattern
+from typing import TypeVar, Generic
+from re import Pattern
 
 ## Installed
 import dnslib

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 requires = tox>=3,tox-uv
-envlist = py{38,39,310,311,312,313,314}, pypy{38,39,310,311}
+envlist = py{310,311,312,313,314}, pypy{310,311}
 
 [testenv]
 description = run unit tests


### PR DESCRIPTION
Per title

### Test Plan

- Run lint and tests